### PR TITLE
Printk, printf, scause errors & more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ entryother
 initcode
 initcode.out
 kernelmemfs
-mkfs
+mkfs/mkfs
 kernel/kernel
 user/usys.S
 .gdbinit
+/.vscode

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ OBJS = \
   $K/trap.o \
   $K/syscall.o \
   $K/sysproc.o \
+  $K/sysown.o \
   $K/bio.o \
   $K/fs.o \
   $K/log.o \
@@ -106,7 +107,7 @@ $U/initcode: $U/initcode.S
 tags: $(OBJS) _init
 	etags *.S *.c
 
-ULIB = $U/ulib.o $U/usys.o $U/printf.o $U/umalloc.o $U/bmalloc.o
+ULIB = $U/ulib.o $U/usys.o $U/printf.o $U/umalloc.o $U/bmalloc.o $U/user.o
 
 _%: %.o $(ULIB)
 	$(LD) $(LDFLAGS) -T $U/user.ld -o $@ $^
@@ -156,6 +157,9 @@ UPROGS=\
 	$U/_malloc_test_cxx\
 	$U/_terminate\
 	$U/_my_mmap\
+	$U/_hello\
+	$U/_hello_kernel\
+	$U/_test_printf\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 K=kernel
 U=user
+O=own
 
 OBJS = \
   $K/entry.o \
@@ -160,6 +161,7 @@ UPROGS=\
 	$U/_hello\
 	$U/_hello_kernel\
 	$U/_test_printf\
+	$O/_test_own\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OBJS = \
   $K/entry.o \
   $K/start.o \
   $K/console.o \
-  $K/printf.o \
+  $K/printk.o \
   $K/uart.o \
   $K/kalloc.o \
   $K/spinlock.o \

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -16,7 +16,7 @@
 
 //
 // send one character to the uart.
-// called by printf(), and to echo input characters,
+// called by printk(), and to echo input characters,
 // but not from write().
 //
 void

--- a/kernel/cxxtest.cc
+++ b/kernel/cxxtest.cc
@@ -2,7 +2,7 @@
 
 template<int What>
 void a_template() {
-	printf(const_cast<char*>("cpp printed: %d\n"), What);
+	printk(const_cast<char*>(KERN_INFO"cpp printed: %d\n"), What);
 }
 extern "C"
 uint64 sys_cxx() {

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -180,6 +180,7 @@ uint64          walkaddr(pagetable_t, uint64);
 int             copyout(pagetable_t, uint64, char *, uint64);
 int             copyin(pagetable_t, char *, uint64, uint64);
 int             copyinstr(pagetable_t, char *, uint64, uint64);
+uint64          print_pt(pagetable_t, int); // prints contents of a page
 
 // plic.c
 void            plicinit(void);

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -87,10 +87,10 @@ void            pipeclose(struct pipe*, int);
 int             piperead(struct pipe*, uint64, int);
 int             pipewrite(struct pipe*, uint64, int);
 
-// printf.c
-void            printf(char*, ...);
+// printk.c
+void            printk(char*, ...);
 void            panic(char*) __attribute__((noreturn));
-void            printfinit(void);
+void            printkinit(void);
 
 // proc.c
 int             cpuid(void);

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -15,7 +15,7 @@ extern "C" {
 #include "kernel/proc.h"
 #include "kernel/stat.h"
 #include "kernel/mmap.h"
-
+#include "kernel/printk.h"
 
 // start.c
 void            timerhalt(void);
@@ -87,10 +87,6 @@ void            pipeclose(struct pipe*, int);
 int             piperead(struct pipe*, uint64, int);
 int             pipewrite(struct pipe*, uint64, int);
 
-// printk.c
-void            printk(char*, ...);
-void            panic(char*) __attribute__((noreturn));
-void            printkinit(void);
 
 // proc.c
 int             cpuid(void);

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -74,7 +74,7 @@ balloc(uint dev)
     }
     brelse(bp);
   }
-  printk("balloc: out of blocks\n");
+  pr_notice("balloc: out of blocks\n");
   return 0;
 }
 
@@ -205,7 +205,7 @@ ialloc(uint dev, short type)
     }
     brelse(bp);
   }
-  printk("ialloc: no inodes\n");
+  pr_notice("ialloc: no inodes\n");
   return 0;
 }
 

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -74,7 +74,7 @@ balloc(uint dev)
     }
     brelse(bp);
   }
-  printf("balloc: out of blocks\n");
+  printk("balloc: out of blocks\n");
   return 0;
 }
 
@@ -205,7 +205,7 @@ ialloc(uint dev, short type)
     }
     brelse(bp);
   }
-  printf("ialloc: no inodes\n");
+  printk("ialloc: no inodes\n");
   return 0;
 }
 

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -9,9 +9,9 @@ main()
   if(cpuid() == 0){
     consoleinit();
     printkinit();
-    printk("\n");
-    printk("xv6 kernel is booting\n");
-    printk("\n");
+    pr_info("\n");
+    pr_info("xv6 kernel is booting\n");
+    pr_info("\n");
     kinit();         // physical page allocator
     kvminit();       // create kernel page table
     kvminithart();   // turn on paging
@@ -31,7 +31,7 @@ main()
     while(started == 0)
       ;
     __sync_synchronize();
-    printk("hart %d starting\n", cpuid());
+    pr_info("hart %d starting\n", cpuid());
     kvminithart();    // turn on paging
     trapinithart();   // install kernel trap vector
     plicinithart();   // ask PLIC for device interrupts

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -8,10 +8,10 @@ main()
 {
   if(cpuid() == 0){
     consoleinit();
-    printfinit();
-    printf("\n");
-    printf("xv6 kernel is booting\n");
-    printf("\n");
+    printkinit();
+    printk("\n");
+    printk("xv6 kernel is booting\n");
+    printk("\n");
     kinit();         // physical page allocator
     kvminit();       // create kernel page table
     kvminithart();   // turn on paging
@@ -31,7 +31,7 @@ main()
     while(started == 0)
       ;
     __sync_synchronize();
-    printf("hart %d starting\n", cpuid());
+    printk("hart %d starting\n", cpuid());
     kvminithart();    // turn on paging
     trapinithart();   // install kernel trap vector
     plicinithart();   // ask PLIC for device interrupts

--- a/kernel/printk.c
+++ b/kernel/printk.c
@@ -135,7 +135,7 @@ panic(char *s)
 {
   pr.locking = 0;
   pr_emerg("panic: ");
-  printk(KERN_EMERG "%s", s); // The only place where a dynamic string is an argument of printk. Thanks
+  pr_emerg("%s", s);
   pr_emerg("\n");
   panicked = 1; // freeze uart output from other CPUs
   timerhalt();

--- a/kernel/printk.c
+++ b/kernel/printk.c
@@ -1,5 +1,5 @@
 //
-// formatted console output -- printf, panic.
+// formatted kernel logging -- printk, panic.
 //
 
 #include <stdarg.h>
@@ -8,7 +8,7 @@
 
 volatile int panicked = 0;
 
-// lock to avoid interleaving concurrent printf's.
+// lock to avoid interleaving concurrent printk's.
 static struct {
   struct spinlock lock;
   int locking;
@@ -52,7 +52,7 @@ printptr(uint64 x)
 
 // Print to the console. only understands %d, %x, %p, %s.
 void
-printf(char *fmt, ...)
+printk(char *fmt, ...)
 {
   va_list ap;
   int i, c, locking;
@@ -110,9 +110,9 @@ void
 panic(char *s)
 {
   pr.locking = 0;
-  printf("panic: ");
-  printf(s);
-  printf("\n");
+  printk("panic: ");
+  printk(s);
+  printk("\n");
   panicked = 1; // freeze uart output from other CPUs
   timerhalt();
   for(;;)
@@ -120,7 +120,7 @@ panic(char *s)
 }
 
 void
-printfinit(void)
+printkinit(void)
 {
   initlock(&pr.lock, "pr");
   pr.locking = 1;

--- a/kernel/printk.h
+++ b/kernel/printk.h
@@ -1,0 +1,29 @@
+#ifndef INCLUDED_kernel_printk_h
+#define INCLUDED_kernel_printk_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define KERN_SOH     "\001"
+#define KERN_EMERG   "0"
+#define KERN_WARNING "1"
+#define KERN_NOTICE  "2"
+#define KERN_INFO    "3"
+
+#define pr_emerg(str, ...)   printk(KERN_EMERG str,  ##__VA_ARGS__)
+#define pr_warning(str, ...) printk(KERN_WARNING str,##__VA_ARGS__)
+#define pr_notice(str, ...)  printk(KERN_NOTICE str, ##__VA_ARGS__)
+#define pr_info(str, ...)    printk(KERN_INFO str,   ##__VA_ARGS__)
+
+// printk.c
+void            printk(char*, ...);
+void            panic(char*) __attribute__((noreturn));
+void            printkinit(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/kernel/printk.h
+++ b/kernel/printk.h
@@ -10,6 +10,15 @@ extern "C" {
 #define KERN_WARNING "1"
 #define KERN_NOTICE  "2"
 #define KERN_INFO    "3"
+#define KERN_DEFAULT "4"
+
+// Integer equivalents of KERN_<LEVEL>
+// Inspired by linux kernel
+#define LOGLEVEL_EMERG    0
+#define LOGLEVEL_WARNING  1
+#define LOGLEVEL_NOTICE   2
+#define LOGLEVEL_INFO     3
+#define LOGLEVEL_DEFAULT  4
 
 #define pr_emerg(str, ...)   printk(KERN_EMERG str,  ##__VA_ARGS__)
 #define pr_warning(str, ...) printk(KERN_WARNING str,##__VA_ARGS__)

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -664,7 +664,7 @@ procdump(void)
   struct proc *p;
   char *state;
 
-  printk("\n");
+  pr_info("\n");
   for(p = proc; p < &proc[NPROC]; p++){
     if(p->state == UNUSED)
       continue;
@@ -672,7 +672,7 @@ procdump(void)
       state = states[p->state];
     else
       state = "???";
-    printk("%d %s %s", p->pid, state, p->name);
-    printk("\n");
+    pr_info("%d %s %s", p->pid, state, p->name);
+    pr_info("\n");
   }
 }

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -664,7 +664,7 @@ procdump(void)
   struct proc *p;
   char *state;
 
-  printf("\n");
+  printk("\n");
   for(p = proc; p < &proc[NPROC]; p++){
     if(p->state == UNUSED)
       continue;
@@ -672,7 +672,7 @@ procdump(void)
       state = states[p->state];
     else
       state = "???";
-    printf("%d %s %s", p->pid, state, p->name);
-    printf("\n");
+    printk("%d %s %s", p->pid, state, p->name);
+    printk("\n");
   }
 }

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -143,7 +143,7 @@ syscall(void)
     // and store its return value in p->trapframe->a0
     p->trapframe->a0 = syscalls[num]();
   } else {
-    printk("%d %s: unknown sys call %d\n",
+    pr_warning("%d %s: unknown sys call %d\n",
             p->pid, p->name, num);
     p->trapframe->a0 = -1;
   }

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -143,7 +143,7 @@ syscall(void)
     // and store its return value in p->trapframe->a0
     p->trapframe->a0 = syscalls[num]();
   } else {
-    printf("%d %s: unknown sys call %d\n",
+    printk("%d %s: unknown sys call %d\n",
             p->pid, p->name, num);
     p->trapframe->a0 = -1;
   }

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -99,6 +99,7 @@ extern uint64 sys_cxx(void);
 extern uint64 sys_term(void);
 extern uint64 sys_mmap(void);
 extern uint64 sys_hello_kernel(void);
+extern uint64 sys_printPT(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -128,6 +129,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_cxx]     sys_cxx,
 [SYS_term]    sys_term,
 [SYS_hello_kernel] sys_hello_kernel,
+[SYS_printPT]  sys_printPT,
 
 };
 

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -98,6 +98,7 @@ extern uint64 sys_close(void);
 extern uint64 sys_cxx(void);
 extern uint64 sys_term(void);
 extern uint64 sys_mmap(void);
+extern uint64 sys_hello_kernel(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,8 @@ static uint64 (*syscalls[])(void) = {
 [SYS_mmap]    sys_mmap,
 [SYS_cxx]     sys_cxx,
 [SYS_term]    sys_term,
+[SYS_hello_kernel] sys_hello_kernel,
+
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -33,6 +33,7 @@ extern "C" {
 #define SYS_mkdir  20
 #define SYS_close  21
 #define SYS_mmap   22
+#define SYS_hello_kernel 22
 #define SYS_cxx    100
 #define SYS_term   101
 

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -33,7 +33,8 @@ extern "C" {
 #define SYS_mkdir  20
 #define SYS_close  21
 #define SYS_mmap   22
-#define SYS_hello_kernel 22
+#define SYS_hello_kernel 50
+#define SYS_printPT 51
 #define SYS_cxx    100
 #define SYS_term   101
 

--- a/kernel/sysown.c
+++ b/kernel/sysown.c
@@ -1,0 +1,16 @@
+#include "types.h"
+#include "param.h"
+#include "memlayout.h"
+#include "riscv.h"
+#include "spinlock.h"
+#include "proc.h"
+#include "syscall.h"
+#include "defs.h"
+
+uint64 sys_hello_kernel(void)
+{
+    int num;
+    argint(0, &num);
+    printf("Hello from Kernel from Group %d\n", num);
+    return 2;
+}

--- a/kernel/sysown.c
+++ b/kernel/sysown.c
@@ -11,6 +11,6 @@ uint64 sys_hello_kernel(void)
 {
     int num;
     argint(0, &num);
-    printf("Hello Kernelspace, Group %d\n", num);
+    printk("Hello Kernelspace, Group %d\n", num);
     return 2;
 }

--- a/kernel/sysown.c
+++ b/kernel/sysown.c
@@ -11,6 +11,6 @@ uint64 sys_hello_kernel(void)
 {
     int num;
     argint(0, &num);
-    printk("Hello Kernelspace, Group %d\n", num);
+    pr_info("Hello Kernelspace, Group %d\n", num);
     return 2;
 }

--- a/kernel/sysown.c
+++ b/kernel/sysown.c
@@ -11,6 +11,6 @@ uint64 sys_hello_kernel(void)
 {
     int num;
     argint(0, &num);
-    printf("Hello from Kernel from Group %d\n", num);
+    printf("Hello Kernelspace, Group %d\n", num);
     return 2;
 }

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -43,6 +43,13 @@ sys_sbrk(void)
 }
 
 uint64
+sys_printPT(void)
+{
+  print_pt(myproc()->pagetable , 3);
+  return 0;
+}
+
+uint64
 sys_sleep(void)
 {
   int n;

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -24,6 +24,28 @@ trapinithart(void)
   w_stvec((uint64)kernelvec);
 }
 
+// scauses and their names according to
+// https://riscv.org/wp-content/uploads/2017/05/riscv-privileged-v1.10.pdf
+// AMO = Atomic Memory Operation
+// Not mapped: Interrupt causes
+static char* scause_map[] = {
+[0]    "Instruction address misaligned",
+[1]    "Instruction address fault",
+[2]    "Illegal instruction",
+[3]    "Breakpoint",
+[4]    "Reserved",
+[5]    "Load access fault",
+[6]    "AMO address misalignd",
+[7]    "Store/AMO access fault",
+// 8, up to (and including) 11
+[8 ... 11]    "Reserved",
+[12]    "Instruction page fault",
+[13]    "Load page fault",
+[14]    "Reserved",
+[15]    "Store/AMO page fault",
+
+};
+
 //
 // handle an interrupt, exception, or system call from user space.
 // called from trampoline.S
@@ -64,6 +86,9 @@ usertrap(void)
     // ok
   } else {
     pr_warning("usertrap(): unexpected scause %p pid=%d\n", r_scause(), p->pid);
+    if (r_scause() < 16) {
+      pr_warning("            %s\n", scause_map[r_scause()]);
+    }
     pr_warning("            sepc=%p stval=%p\n", r_sepc(), r_stval());
     setkilled(p);
   }

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -63,8 +63,8 @@ usertrap(void)
   } else if((which_dev = devintr()) != 0){
     // ok
   } else {
-    printf("usertrap(): unexpected scause %p pid=%d\n", r_scause(), p->pid);
-    printf("            sepc=%p stval=%p\n", r_sepc(), r_stval());
+    printk("usertrap(): unexpected scause %p pid=%d\n", r_scause(), p->pid);
+    printk("            sepc=%p stval=%p\n", r_sepc(), r_stval());
     setkilled(p);
   }
 
@@ -140,8 +140,8 @@ kerneltrap()
     panic("kerneltrap: interrupts enabled");
 
   if((which_dev = devintr()) == 0){
-    printf("scause %p\n", scause);
-    printf("sepc=%p stval=%p\n", r_sepc(), r_stval());
+    printk("scause %p\n", scause);
+    printk("sepc=%p stval=%p\n", r_sepc(), r_stval());
     panic("kerneltrap");
   }
 
@@ -186,7 +186,7 @@ devintr()
     } else if(irq == VIRTIO0_IRQ){
       virtio_disk_intr();
     } else if(irq){
-      printf("unexpected interrupt irq=%d\n", irq);
+      printk("unexpected interrupt irq=%d\n", irq);
     }
 
     // the PLIC allows each device to raise at most one

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -63,8 +63,8 @@ usertrap(void)
   } else if((which_dev = devintr()) != 0){
     // ok
   } else {
-    printk("usertrap(): unexpected scause %p pid=%d\n", r_scause(), p->pid);
-    printk("            sepc=%p stval=%p\n", r_sepc(), r_stval());
+    pr_warning("usertrap(): unexpected scause %p pid=%d\n", r_scause(), p->pid);
+    pr_warning("            sepc=%p stval=%p\n", r_sepc(), r_stval());
     setkilled(p);
   }
 
@@ -140,8 +140,8 @@ kerneltrap()
     panic("kerneltrap: interrupts enabled");
 
   if((which_dev = devintr()) == 0){
-    printk("scause %p\n", scause);
-    printk("sepc=%p stval=%p\n", r_sepc(), r_stval());
+    pr_emerg("scause %p\n", scause);
+    pr_emerg("sepc=%p stval=%p\n", r_sepc(), r_stval());
     panic("kerneltrap");
   }
 
@@ -186,7 +186,7 @@ devintr()
     } else if(irq == VIRTIO0_IRQ){
       virtio_disk_intr();
     } else if(irq){
-      printk("unexpected interrupt irq=%d\n", irq);
+      pr_notice("unexpected interrupt irq=%d\n", irq);
     }
 
     // the PLIC allows each device to raise at most one

--- a/kernel/uart.c
+++ b/kernel/uart.c
@@ -40,7 +40,7 @@ char uart_tx_buf[UART_TX_BUF_SIZE];
 uint64 uart_tx_w; // write next to uart_tx_buf[uart_tx_w % UART_TX_BUF_SIZE]
 uint64 uart_tx_r; // read next from uart_tx_buf[uart_tx_r % UART_TX_BUF_SIZE]
 
-extern volatile int panicked; // from printf.c
+extern volatile int panicked; // from printk.c
 
 void uartstart();
 
@@ -100,7 +100,7 @@ uartputc(int c)
 
 
 // alternate version of uartputc() that doesn't 
-// use interrupts, for use by kernel printf() and
+// use interrupts, for use by kernel printk() and
 // to echo characters. it spins waiting for the uart's
 // output register to be empty.
 void

--- a/own/test.c
+++ b/own/test.c
@@ -1,0 +1,10 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+
+void main(int argc, char** argv)
+{
+
+	
+	printf("TESTING from own");
+}

--- a/own/test_own.c
+++ b/own/test_own.c
@@ -1,10 +1,7 @@
 #include "kernel/types.h"
 #include "user/user.h"
 
-
 void main(int argc, char** argv)
 {
-
-	
-	printf("TESTING from own");
-}
+    printf("Hello from my own folder!\n");
+} 

--- a/rt-test/printPT-test.c
+++ b/rt-test/printPT-test.c
@@ -1,0 +1,7 @@
+#include "user/user.h"
+
+
+void main(int argc, char** argv) 
+{
+    printPT();
+}

--- a/user/hello.c
+++ b/user/hello.c
@@ -9,5 +9,5 @@ void main(int argc, char** argv)
 		printf("Not enough Args");
 		exit(-1);
 	}
-	printf("Hello World from Group %s\n", argv[1]);
+	printf("Hello Userspace, Group %s\n", argv[1]);
 }

--- a/user/hello.c
+++ b/user/hello.c
@@ -1,0 +1,13 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+
+void main(int argc, char** argv)
+{
+
+	if (argc < 2) {
+		printf("Not enough Args");
+		exit(-1);
+	}
+	printf("Hello World from Group %s\n", argv[1]);
+}

--- a/user/hello_kernel.c
+++ b/user/hello_kernel.c
@@ -1,0 +1,12 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+void main (int argc, char** argv)
+{
+    if (argc < 2) {
+        printf("Error: Not enough arguments\n");
+        exit(-1);
+    }
+    int number = atoi(argv[1]);
+    hello_kernel(number);
+}

--- a/user/printf.c
+++ b/user/printf.c
@@ -103,7 +103,7 @@ vprintf(int fd, const char *fmt, va_list ap)
           printint(fd, va_arg(ap, long), 10, 0);
           break;
         default:
-          printint(fd, va_arg(ap, int), 10, 1);
+          printint(fd, va_arg(ap, int), 10, 0);
           putc(fd, c);
           break;
       }

--- a/user/test_printf.c
+++ b/user/test_printf.c
@@ -1,0 +1,12 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+void main(int argc, char **argv) {
+    printf("%d, %d, %d\n", 12,-12, 0xFFFFFFFFF);
+    printf("%l, %l\n", 0xFFFFFFFFF, -0xFFFFFFFFF);
+    printf("%x, %x\n", 0xFF, -0xFF);
+    printf("%p\n", 0xFFFFFFFFF);
+    printf("%s\n", "hi");
+    printf("%u, %u\n", 12,-12);
+    printf("%ul, %ul\n", 0xFFFFFFFFF, -0xFFFFFFFFF);
+}

--- a/user/test_printf.c
+++ b/user/test_printf.c
@@ -2,11 +2,13 @@
 #include "user/user.h"
 
 void main(int argc, char **argv) {
-    printf("%d, %d, %d\n", 12,-12, 0xFFFFFFFFF);
+    printf("%d, %d, %d\n", 12,-12, 0xFFFFFFFFE);
     printf("%l, %l\n", 0xFFFFFFFFF, -0xFFFFFFFFF);
     printf("%x, %x\n", 0xFF, -0xFF);
     printf("%p\n", 0xFFFFFFFFF);
     printf("%s\n", "hi");
     printf("%u, %u\n", 12,-12);
     printf("%ul, %ul\n", 0xFFFFFFFFF, -0xFFFFFFFFF);
+    printf("%b, %b, %b, %b, %b\n", 0b0100, 0b1000000, 0xFF0FF, 2, 0xFFFFFFFFF);
+    printf("%l, %x, %b\n", -1, -1, -1);
 }

--- a/user/test_printf.c
+++ b/user/test_printf.c
@@ -8,7 +8,8 @@ void main(int argc, char **argv) {
     printf("%p\n", 0xFFFFFFFFF);
     printf("%s\n", "hi");
     printf("%u, %u\n", 12,-12);
-    printf("%ul, %ul\n", 0xFFFFFFFFF, -0xFFFFFFFFF);
+    printf("%lu, %lu\n", 0xFFFFFFFFF, -0xFFFFFFFFF);
+    printf("%lul\n", 0xFFF);
     printf("%b, %b, %b, %b, %b\n", 0b0100, 0b1000000, 0xFF0FF, 2, 0xFFFFFFFFF);
     printf("%l, %x, %b\n", -1, -1, -1);
 }

--- a/user/user.c
+++ b/user/user.c
@@ -5,52 +5,58 @@
 /**
  * Moves syscall number into a7 register, calls ecall
  */
-#define SYSCALL(number) \
-    asm volatile(       \
-    "li a7, %0\n"       \
-    "ecall\n"           \
-    :                   \
+#define SYSCALL(number)      \
+    asm volatile(            \
+    "li a7, %0\n"            \
+    "ecall\n"                \
+    :                        \
     :"i"(number))
 
 /**
  * Puts a system call return value from a0 register into a given variable.
  * All system calls return 64 Bit Values.
  */ 
-#define SCGETRETURN(rVal) \
-    asm volatile(             \
-        "sw a0, %0\n"         \
-        :"=m"(rVal)      \
+#define SCGETRETURN(rVal)    \
+    asm volatile(            \
+        "sw a0, %0\n"        \
+        :"=m"(rVal)          \
     )
 
 /**
- * Saves a0-a5 registers inside an array starting with aStart.
- * Only a0-a5 are supported for syscall arguments, as seen in argraw in syscall.c
+ * Saves a0-a5 registers inside an array.
+ * Only a0-a5 are supported for syscall arguments, as seen in argraw in syscall.c, so only those are saved.
 */
-#define SCSAVEARGS(arr) \
-    asm volatile(            \
-        "sw a0, %0\n"        \
-        "sw a1, %1\n"        \
-        "sw a2, %2\n"        \
-        "sw a3, %3\n"        \
-        "sw a4, %4\n"        \
-        "sw a5, %5\n"        \
-        :"=m"(arr[0]),"=m"(arr[1]),"=m"(arr[2]),"=m"(arr[3]),"=m"(arr[4]),"=m"(arr[5])\
+#define SCSAVEARGS(arr)       \
+    asm volatile(             \
+        "sw a0, (0)%0\n"      \
+        "sw a1, (8)%0\n"      \
+        "sw a2, (16)%0\n"     \
+        "sw a3, (24)%0\n"     \
+        "sw a4, (32)%0\n"     \
+        "sw a5, (40)%0\n"     \
+        :"=o"(arr)            \
     )                        
 
 /**
  * Restores registers a0 to a5 from inside an array.
 */
-#define SCRESTOREARGS(arr) \
-    asm volatile(            \
-        "lw a0, %0\n"        \
-        "lw a1, %1\n"        \
-        "lw a2, %2\n"        \
-        "lw a3, %3\n"        \
-        "lw a4, %4\n"        \
-        "lw a5, %5\n"        \
-        :                    \
-        :"m"(arr[0]),"m"(arr[1]),"m"(arr[2]),"m"(arr[3]),"m"(arr[4]),"m"(arr[5])\
+#define SCRESTOREARGS(arr)    \
+    asm volatile(             \
+        "lw a0, (0)%0\n"      \
+        "lw a1, (8)%0\n"      \
+        "lw a2, (16)%0\n"     \
+        "lw a3, (24)%0\n"     \
+        "lw a4, (32)%0\n"     \
+        "lw a5, (40)%0\n"     \
+        :                     \
+        :"o"(arr)             \
     )   
+
+void debugSCRegs(uint64 arr[6]) {
+    for(int i = 0; i < 6; i++) {
+        printf("a%d:%ul\n",i,arr[i]);
+    }
+}
 
 /**
  * Handler for hello_kernel system call
@@ -68,7 +74,6 @@ int hello_kernel(int group)
     }
     
     SCRESTOREARGS(registers);
-
     SYSCALL(SYS_hello_kernel);
     uint64 rVal = 0;
     SCGETRETURN(rVal);

--- a/user/user.c
+++ b/user/user.c
@@ -1,0 +1,76 @@
+#include "kernel/syscall.h"
+#include "kernel/types.h"
+#include "user/user.h"
+
+/**
+ * Moves syscall number into a7 register, calls ecall
+ */
+#define SYSCALL(number) \
+    asm volatile(       \
+    "li a7, %0\n"       \
+    "ecall\n"           \
+    :                   \
+    :"i"(number))
+
+/**
+ * Puts a system call return value from a0 register into a given variable.
+ * All system calls return 64 Bit Values.
+ */ 
+#define SCGETRETURN(rVal) \
+    asm volatile(             \
+        "sw a0, %0\n"         \
+        :"=m"(rVal)      \
+    )
+
+/**
+ * Saves a0-a5 registers inside an array starting with aStart.
+ * Only a0-a5 are supported for syscall arguments, as seen in argraw in syscall.c
+*/
+#define SCSAVEARGS(arr) \
+    asm volatile(            \
+        "sw a0, %0\n"        \
+        "sw a1, %1\n"        \
+        "sw a2, %2\n"        \
+        "sw a3, %3\n"        \
+        "sw a4, %4\n"        \
+        "sw a5, %5\n"        \
+        :"=m"(arr[0]),"=m"(arr[1]),"=m"(arr[2]),"=m"(arr[3]),"=m"(arr[4]),"=m"(arr[5])\
+    )                        
+
+/**
+ * Restores registers a0 to a5 from inside an array.
+*/
+#define SCRESTOREARGS(arr) \
+    asm volatile(            \
+        "lw a0, %0\n"        \
+        "lw a1, %1\n"        \
+        "lw a2, %2\n"        \
+        "lw a3, %3\n"        \
+        "lw a4, %4\n"        \
+        "lw a5, %5\n"        \
+        :                    \
+        :"m"(arr[0]),"m"(arr[1]),"m"(arr[2]),"m"(arr[3]),"m"(arr[4]),"m"(arr[5])\
+    )   
+
+/**
+ * Handler for hello_kernel system call
+*/
+int hello_kernel(int group)
+{
+    uint64 registers[6] = {0};
+    SCSAVEARGS(registers);
+    /**
+     * Do arg checking between SCSAVEARGS and SCRESTOREARGS
+    */
+    if (group > 33) {
+        printf("There aren't that many groups, dummy\n");
+        return -1;
+    }
+    
+    SCRESTOREARGS(registers);
+
+    SYSCALL(SYS_hello_kernel);
+    uint64 rVal = 0;
+    SCGETRETURN(rVal);
+    return rVal;
+} 

--- a/user/user.h
+++ b/user/user.h
@@ -38,6 +38,7 @@ int uptime(void);
 void* mmap(void*, int, int, int);
 void cxx(int);
 void term();
+int hello_kernel(int);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/user.h
+++ b/user/user.h
@@ -39,6 +39,7 @@ void* mmap(void*, int, int, int);
 void cxx(int);
 void term();
 int hello_kernel(int);
+int printPT(void);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -39,4 +39,5 @@ entry("uptime");
 entry("cxx");
 entry("term");
 entry("mmap")
+entry("printPT");
 

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -38,6 +38,6 @@ entry("sleep");
 entry("uptime");
 entry("cxx");
 entry("term");
-entry("mmap")
+entry("mmap");
 entry("printPT");
 


### PR DESCRIPTION
Took a while but here are my changes:

Summary:

"Major":
- renamed printf in kernel to printk, supports log levels (colors). Log levels are *required* or it won't print the first char
- Unexpected scause error cause printing
- My version of printf with support for long, int printing in hex, dec (+unsigned) and bin

Minor additions:
- My version of the hello_kernel syscall (can remove)
- My version of hello_world (can remove)
- A test for printf (can remove)
